### PR TITLE
在Version Control 视图中新添加create patcher菜单，方便根据修改的文件生成增量包

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -25,6 +25,8 @@
         <!--    设置 idea Action    -->
         <action id="ldx.patcher" class="com.CreatePatcherAction" text="Create Patcher" description="Create Java SE and Java EE project patch files.">
             <add-to-group group-id="ProjectViewPopupMenu" anchor="first"/>
+            <add-to-group group-id="Vcs.Log.ChangesBrowser.Popup" anchor="first"/><!-- Version Control-Log  -->
+            <add-to-group group-id="ChangesViewPopupMenu" anchor="first"/>      <!-- Version Control-Local Change  -->
             <keyboard-shortcut first-keystroke="shift alt E" keymap="$default"/>
         </action>
     </actions>

--- a/src/com/ldx/PatcherEnum.java
+++ b/src/com/ldx/PatcherEnum.java
@@ -24,7 +24,7 @@ class PatcherEnum {
     /**
      * webPath
      */
-    static final String[] WEB_PATH = {"WebRoot", "webapp"};
+    static final String[] WEB_PATH = {"WebRoot", "webapp","WebContent"};
 
     /**
      * 桌面路径


### PR DESCRIPTION
您好，patcher插件帮助我节约了好多打增量包的时间，非常感激；
1.在使用过程中，为了更方便的打包，我在Version Control 视图也添加了create patcher菜单，这样可以直接一次将修改的文件打包：
![image](https://user-images.githubusercontent.com/7012774/74843046-4fdeea00-5366-11ea-951d-8f1bc3cbeb0d.png)
![image](https://user-images.githubusercontent.com/7012774/74843352-be23ac80-5366-11ea-8be9-6189dffe3abb.png)
2.web Path中增加了WebContent下拉选项
![image](https://user-images.githubusercontent.com/7012774/74843523-0216b180-5367-11ea-933e-7d9e4ce32c6b.png)



